### PR TITLE
Fix imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+help: ## Shows this help
+	@echo "$$(grep -h '#\{2\}' $(MAKEFILE_LIST) | sed 's/: #\{2\} /	/' | column -t -s '	')"
+
+test: ## Run test suite
+	python -m unittest
+
+lint: ## Check for lint errors
+	flake8
+
+publish: ## Publish to PyPI
+	[ "$$(git rev-parse --abbrev-ref HEAD)" == "master" ]
+	git pull
+	poetry publish

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ class SimpleTest(TestCase):
 
 If you're using a custom `Client`, you can use the mixin version:
 
-```
+```python
 from django.test import Client
 from django_test_curl import CurlClientMixin
 

--- a/django_test_curl/__init__.py
+++ b/django_test_curl/__init__.py
@@ -1,1 +1,4 @@
 from .django_test_curl import CurlClient, CurlClientMixin  # noqa
+
+# TODO how do I get the version from pyproject.toml here? flit seems to have a
+# solution

--- a/django_test_curl/__init__.py
+++ b/django_test_curl/__init__.py
@@ -1,0 +1,1 @@
+from .django_test_curl import CurlClient, CurlClientMixin  # noqa

--- a/django_test_curl/django_test_curl.py
+++ b/django_test_curl/django_test_curl.py
@@ -20,6 +20,16 @@ class CurlClientMixin:
     def curl(self, cmd: str) -> HttpResponse:
         """
         Use curl syntax to do a test client request
+
+        Parameters
+        ----------
+        cmd
+            The full curl command, including ``curl``. The scheme and host
+            don't matter.
+
+        Returns
+        -------
+        HttpResponse
         """
         curl_cmd, *args = shlex.split(cmd)
         assert curl_cmd == 'curl'

--- a/django_test_curl/test_django_test_curl.py
+++ b/django_test_curl/test_django_test_curl.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import patch
 
-from .django_test_curl import CurlClient
+from . import CurlClient
 
 
 class CurlTests(unittest.TestCase):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [flake8]
+exclude = dist
 max-line-length = 100


### PR DESCRIPTION
The imports weren't following the README. This makes the README examples work and adds a bit more boilerplate.