### PR TITLE
Fix how get parameters weren't passed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
-python: "3.7-dev"
+dist: xenial
+python: "3.7"
 install: pip install Django
 script: python -m unittest

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ lint: ## Check for lint errors
 # 2. run `make publish`
 # 3. git commit -am "0.0.0"
 # 4. git tag "v0.0.0"
-# 5. git push origin master
 # 5. git push origin master --tags
 publish: ## Publish to PyPI
 	[ "$$(git rev-parse --abbrev-ref HEAD)" == "master" ]

--- a/django_test_curl/django_test_curl.py
+++ b/django_test_curl/django_test_curl.py
@@ -47,6 +47,11 @@ class CurlClientMixin:
 
         kwargs = {}
 
+        path = url.path
+
+        if url.query:
+            path = f'{path}?{url.query}'
+
         if url.username and url.password:
             hashcode = base64.b64encode(f'{url.username}:{url.password}'.encode('utf-8'))
             kwargs['HTTP_AUTHORIZATION'] = f'Basic {hashcode.decode("utf8")}'
@@ -60,7 +65,7 @@ class CurlClientMixin:
         if opts.data:
             kwargs['data'] = opts.data
 
-        return getattr(self, opts.request)(url.path, **headers, **kwargs)
+        return getattr(self, opts.request)(path, **headers, **kwargs)
 
 
 class CurlClient(CurlClientMixin, BaseClient):

--- a/django_test_curl/test_django_test_curl.py
+++ b/django_test_curl/test_django_test_curl.py
@@ -35,6 +35,15 @@ class CurlTests(unittest.TestCase):
         )
         mock_req.assert_called_once_with('/api/v1/poop/')
 
+    @patch.object(CurlClient, 'get')
+    def test_curl_extracts_get_params(self, mock_req):
+        self.client.curl(
+            """
+            curl 'http://localhost:8000/api/v1/poop/?foo=a&foo=b'
+            """
+        )
+        mock_req.assert_called_once_with('/api/v1/poop/?foo=a&foo=b')
+
     @patch.object(CurlClient, 'head')
     def test_curl_sees_head_implies_head(self, mock_req):
         self.client.curl(

--- a/django_test_curl/test_django_test_curl.py
+++ b/django_test_curl/test_django_test_curl.py
@@ -17,6 +17,24 @@ class CurlTests(unittest.TestCase):
         )
         mock_req.assert_called_once_with('/api/v1/poop/')
 
+    @patch.object(CurlClient, 'get')
+    def test_curl_extracts_single_quoted_url(self, mock_req):
+        self.client.curl(
+            """
+            curl 'http://localhost:8000/api/v1/poop/'
+            """
+        )
+        mock_req.assert_called_once_with('/api/v1/poop/')
+
+    @patch.object(CurlClient, 'get')
+    def test_curl_extracts_quoted_url(self, mock_req):
+        self.client.curl(
+            """
+            curl "http://localhost:8000/api/v1/poop/"
+            """
+        )
+        mock_req.assert_called_once_with('/api/v1/poop/')
+
     @patch.object(CurlClient, 'head')
     def test_curl_sees_head_implies_head(self, mock_req):
         self.client.curl(

--- a/django_test_curl/test_django_test_curl.py
+++ b/django_test_curl/test_django_test_curl.py
@@ -18,15 +18,6 @@ class CurlTests(unittest.TestCase):
         mock_req.assert_called_once_with('/api/v1/poop/')
 
     @patch.object(CurlClient, 'get')
-    def test_curl_extracts_single_quoted_url(self, mock_req):
-        self.client.curl(
-            """
-            curl 'http://localhost:8000/api/v1/poop/'
-            """
-        )
-        mock_req.assert_called_once_with('/api/v1/poop/')
-
-    @patch.object(CurlClient, 'get')
     def test_curl_extracts_quoted_url(self, mock_req):
         self.client.curl(
             """


### PR DESCRIPTION
Testing get parameters wasn't covered before. It turns out it didn't work! This fixes that.